### PR TITLE
Grammar review

### DIFF
--- a/DesignDocs/IR_Layering.md
+++ b/DesignDocs/IR_Layering.md
@@ -1,14 +1,16 @@
 IR Layering
 ===========
 
-Feature GOTO library will support `Multi-Layering IR` to make more simplified, specific kind of process on each layer.
+GOTO will support `Multi-Layering IR` for a more modular, simplified code generation process.
 
 Optimization Benefits
 ---------------------
 
-In optimziation benefits. for example, some kind of `Branch Elimination Optimization` or `Inline Optimization` can always useful on most of cpu architectures(like x86_64, ARM, etcs). So the goal is make optimization general and easier, which means more simplified IR code will be performed on highests level of IR layer. in another word, more specific IR layer, will perform more specific optimization, which something like `set[cond] instruction optimization`, `EH optimziation`, `cmov optimization` so IR Layering will decrease dependencies of each optimizations.
+The goal of GOTO is to make optimization passes easy to modify and extend. This means we need a more simplified IR than most currently used formats. The programming language will be described in the highest level IR. Lower, more specific IR layers, will be used for specific optimizations like `set[cond] instruction optimization`, `EH optimziation`, `cmov optimization`. We call this *IR Layering* and IR Layering will decrease dependencies of each optimizations stages.
 
 IR Highering / Lowering
 -----------------------
 
-The IR Lowering will perform same as another compiler frameworks, except it will lowered in each layer. `Layer 4` can only lower to `Layer 3`, and `Layer 3` can only lower to `Layer 2` to make less dependencies and high transform potential. so high transform slots will make IR to highering, which means specific assembly of IR nodes which is `Layer 1` can transform into `Layer 2` more easily than just transforming `Machine Assembly` into `IR` to support JIT virtualization. for example this will makes JIT crossgenning on `x86` to `ARM64.`
+IR Lowering will be performed just as other compiler frameworks, except it will be lowered in each layer. `Layer 4` can only lower to `Layer 3`, and `Layer 3` can only lower to `Layer 2`. This will reduce the cross-layer dependencies and improve transform potential.
+
+*High transform slots* will implement IR highering to implement features such as JIT crossgening from `x86` to `ARM64`. Highering is easier across IR nodes than from assembly to IR. For example the IR of `Layer 1` can be transformed to `Layer 2` more easily than transforming `Machine Assembly` to `IR`. This is often used to support JIT virtualization.


### PR DESCRIPTION
Changed a few sentences for readability. Some changes might not reflect the original meaning. Please check.

BTW, `In compiler optimziation, Branch Elimination Optimization or Inline Optimization is almost always useful on most modern CPU architectures (like x86_64, ARM, etcs). ` Why is this sentence present?